### PR TITLE
fix(bugs): fix fieldMatch validators of formly.config

### DIFF
--- a/src/component/formly.config.js
+++ b/src/component/formly.config.js
@@ -504,6 +504,9 @@ const types = [
     name: 'matchField',
     defaultOptions: function matchFieldDefaultOptions(options) {
       return {
+        extras: {
+          validateOnModelChange: true
+        },
         validators: {
           fieldMatch: {
             expression: (viewValue, modelValue, fieldScope) => {


### PR DESCRIPTION
## Fix bugs
Fixes: mxcloud/thingspro-webapp#133

## Description
修正兩個欄位在進行值比對時，其中一個欄位的值發生改變時，不會觸發 validators。  
目前是用 validateOnModelChange: true 去修正此問題，不過 validateOnModelChange 會觀察所有 formly-field model 的值變化，所以修改其他不相關的欄位時，也會觸發 validators。因此當 formly field太多時可能會有效能問題。